### PR TITLE
Update default branch references from master to main

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -2,12 +2,12 @@ name: Downgrade
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -3,10 +3,10 @@ name: format-check
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -3,12 +3,12 @@ name: "Tests"
 on:
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Dev Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://docs.sciml.ai/SparseBandedMatrices/dev/)
 
 [![CI](https://github.com/SciML/SparseBandedMatrices.jl/actions/workflows/Tests.yml/badge.svg)](https://github.com/SciML/SparseBandedMatrices.jl/actions/workflows/Tests.yml)
-[![codecov](https://codecov.io/gh/SciML/SparseBandedMatrices.jl/branch/master/graph/badge.svg?)](https://codecov.io/gh/SciML/SparseBandedMatrices.jl)
+[![codecov](https://codecov.io/gh/SciML/SparseBandedMatrices.jl/branch/main/graph/badge.svg?)](https://codecov.io/gh/SciML/SparseBandedMatrices.jl)
 [![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/SparseBandedMatrices)](https://pkgs.genieframework.com?packages=SparseBandedMatrices)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,7 @@ makedocs(;
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",
         canonical = "https://docs.sciml.ai/SparseBandedMatrices/stable/",
-        edit_link = "master",
+        edit_link = "main",
         assets = String[],
     ),
     pages = [
@@ -22,5 +22,5 @@ makedocs(;
 
 deploydocs(;
     repo = "github.com/SciML/SparseBandedMatrices.jl",
-    devbranch = "master",
+    devbranch = "main",
 )


### PR DESCRIPTION
## Summary
- Updated all references from "master" branch to "main" branch throughout the repository to follow modern Git conventions

## Changes

This PR updates branch references to align with GitHub's default branch naming:

### GitHub Actions Workflows
- **Tests.yml**: Updated trigger branches from master to main
- **Docs.yml**: Updated trigger branch from master to main  
- **Downgrade.yml**: Updated trigger branches from master to main
- **FormatCheck.yml**: Updated trigger branches from master to main

### Documentation
- **docs/make.jl**: Updated `edit_link` and `devbranch` from master to main

### README
- Updated codecov badge URL to reference main branch instead of master

## Rationale
GitHub now uses "main" as the default branch name for new repositories. This change brings SparseBandedMatrices.jl in line with modern conventions and GitHub's defaults.

## Test plan
- [x] All workflow files correctly reference main branch
- [x] Documentation configuration uses main branch
- [x] README badges point to main branch
- [ ] Workflows trigger correctly after merge to main branch

🤖 Generated with [Claude Code](https://claude.ai/code)