### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -15,5 +15,4 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Canonical CI cleanup for SciML/SparseBandedMatrices.jl.

- TagBot.yml: replaced the inlined JuliaRegistries/TagBot step with the canonical thin caller (`SciML/.github/.github/workflows/tagbot.yml@v1`). Not a monorepo, so no subpackage matrix.
- Downgrade.yml: removed stdlib skip list (Pkg,TOML); julia-version left as 1 (not 1.10/1.11).

Static validation only: edited YAML parsed with PyYAML and TOML parsed with tomli/Julia TOML. No instantiate/precompile/tests run.

Ignore until reviewed by @ChrisRackauckas.