### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,5 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 LinearAlgebra = "1"
-PrecompileTools = "1"
+PrecompileTools = "1.1"
 julia = "1.10"

--- a/src/SparseBandedMatrices.jl
+++ b/src/SparseBandedMatrices.jl
@@ -1,7 +1,8 @@
 module SparseBandedMatrices
 
-using LinearAlgebra, .Threads
-using PrecompileTools
+import LinearAlgebra: mul!
+using .Threads: @threads
+using PrecompileTools: @setup_workload, @compile_workload
 
 """
     SparseBandedMatrix{T} <: AbstractMatrix{T}
@@ -165,7 +166,7 @@ function setdiagonal!(M::SparseBandedMatrix{T}, diagvals, lower::Bool) where {T}
 end
 
 # C = Cb + aAB
-function LinearAlgebra.mul!(C::Matrix{T}, A::SparseBandedMatrix{T}, B::Matrix{T}, a::Number, b::Number) where {T}
+function mul!(C::Matrix{T}, A::SparseBandedMatrix{T}, B::Matrix{T}, a::Number, b::Number) where {T}
     @assert size(A, 2) == size(B, 1)
     @assert size(A, 1) == size(C, 1)
     @assert size(B, 2) == size(C, 2)
@@ -200,7 +201,7 @@ function LinearAlgebra.mul!(C::Matrix{T}, A::SparseBandedMatrix{T}, B::Matrix{T}
 end
 
 # C = C*b + a*B*A
-function LinearAlgebra.mul!(C::Matrix{T}, A::Matrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
+function mul!(C::Matrix{T}, A::Matrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
     @assert size(A, 2) == size(B, 1)
     @assert size(A, 1) == size(C, 1)
     @assert size(B, 2) == size(C, 2)
@@ -230,7 +231,7 @@ function LinearAlgebra.mul!(C::Matrix{T}, A::Matrix{T}, B::SparseBandedMatrix{T}
     return C
 end
 
-function LinearAlgebra.mul!(C::SparseBandedMatrix{T}, A::SparseBandedMatrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
+function mul!(C::SparseBandedMatrix{T}, A::SparseBandedMatrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
     @assert size(A, 2) == size(B, 1)
     @assert size(A, 1) == size(C, 1)
     @assert size(B, 2) == size(C, 2)
@@ -279,7 +280,7 @@ function LinearAlgebra.mul!(C::SparseBandedMatrix{T}, A::SparseBandedMatrix{T}, 
     return C
 end
 
-function LinearAlgebra.mul!(C::Matrix{T}, A::SparseBandedMatrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
+function mul!(C::Matrix{T}, A::SparseBandedMatrix{T}, B::SparseBandedMatrix{T}, a::Number, b::Number) where {T}
     @assert size(A, 2) == size(B, 1)
     @assert size(A, 1) == size(C, 1)
     @assert size(B, 2) == size(C, 2)

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseBandedMatrices = "bd59d7e1-4699-4102-944e-d05209cb92aa"
@@ -13,8 +12,7 @@ SparseBandedMatrices = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-LinearAlgebra = "1"
 SafeTestsets = "0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,32 +1,3 @@
-using SparseBandedMatrices, Aqua, JET, LinearAlgebra, Test
+using SciMLTesting, SparseBandedMatrices, JET, Test
 
-@testset "Aqua" begin
-    Aqua.test_all(SparseBandedMatrices; ambiguities = (recursive = false,))
-end
-
-@testset "JET static analysis" begin
-    # Test that there are no unresolved dispatch errors in key functions
-    @testset "Error-free analysis" begin
-        rep = JET.report_call(getindex, (SparseBandedMatrix{Float64}, Int, Int))
-        @test length(JET.get_reports(rep)) == 0
-
-        rep = JET.report_call(setindex!, (SparseBandedMatrix{Float64}, Float64, Int, Int))
-        @test length(JET.get_reports(rep)) == 0
-
-        rep = JET.report_call(size, (SparseBandedMatrix{Float64},))
-        @test length(JET.get_reports(rep)) == 0
-
-        rep = JET.report_call(setdiagonal!, (SparseBandedMatrix{Float64}, Vector{Float64}, Bool))
-        @test length(JET.get_reports(rep)) == 0
-    end
-
-    @testset "Type stability for core operations" begin
-        # Test getindex type stability
-        rep = JET.report_opt(getindex, (SparseBandedMatrix{Float64}, Int, Int))
-        @test length(JET.get_reports(rep)) == 0
-
-        # Test size type stability
-        rep = JET.report_opt(size, (SparseBandedMatrix{Float64},))
-        @test length(JET.get_reports(rep)) == 0
-    end
-end
+run_qa(SparseBandedMatrices; explicit_imports = true)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Converts `test/qa/qa.jl` to the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled:

```julia
using SciMLTesting, SparseBandedMatrices, JET, Test

run_qa(SparseBandedMatrices; explicit_imports = true)
```

This replaces the hand-rolled Aqua + bespoke JET (`report_call`/`report_opt`) qa.jl. Aqua now runs `test_all` with full defaults (the previous `ambiguities = (recursive = false,)` tweak was a no-op here — `test_all` passes with defaults), JET runs the canonical `test_package` (`mode = :typo`), and the six ExplicitImports checks are enabled.

### ExplicitImports findings (all resolved by FIX; nothing ignored or marked broken)

`check_no_implicit_imports` flagged LinearAlgebra (`LinearAlgebra`, `I`, `mul!`) and PrecompileTools (`PrecompileTools`, `@setup_workload`, `@compile_workload`). Made the imports explicit in `src/`:

```julia
import LinearAlgebra: mul!
using .Threads: @threads
using PrecompileTools: @setup_workload, @compile_workload
```

- `mul!` is now extended via the bare imported name (was `LinearAlgebra.mul!`).
- The `I` flag was a **false positive** — it is the varargs parameter `I::Int...` in `getindex`/`setindex!`, not `LinearAlgebra.I`. It disappears once the blanket `using LinearAlgebra` is gone.
- All 6 EI checks pass; no `ei_kwargs` ignores and no `ei_broken` entries are needed.

No `aqua_broken`/`jet_broken`/`ei_broken` markers (none were present before, and nothing newly fails).

### Deps

- `test/qa/Project.toml`: SciMLTesting compat floor `1` → `1.6`; dropped the now-unused `LinearAlgebra` dep (qa.jl no longer uses it). ExplicitImports stays transitive via SciMLTesting (not added). Aqua / JET / SafeTestsets kept (Aqua's ambiguities child-process + JET + the `@safetestset` harness need them resolvable in the env).
- `Project.toml`: bump PrecompileTools compat floor `1` → `1.1`. Because the package now explicit-imports only PrecompileTools' macros, the macro expansion references the bare `PrecompileTools` module name, which is undefined under 1.0 (`UndefVarError` on load) — verified by pinning 1.0.0. 1.1 is the first self-contained-macro release; verified the package loads at the 1.1 floor.

### Verification (local, Julia 1.10, released SciMLTesting 1.6.0)

- **QA group**: 18/18 pass — Aqua 11, JET 1, ExplicitImports 6. 0 FAIL/ERROR/BROKEN.
- **Core group**: 41/41 pass (constructors 4, division 3, interface 31, multiplication 3) — confirms the `mul!` extension change is behavior-preserving.
- Downgrade floor check: package loads cleanly with PrecompileTools pinned to 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)