### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseBandedMatrices"
 uuid = "bd59d7e1-4699-4102-944e-d05209cb92aa"
 authors = ["Shreyas Ekanathan, Oscar Smith"]
-version = "1.3.2"
+version = "1.3.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Automated patch version bump (1.3.2 -> 1.3.3) to release unreleased commits on `main` via JuliaRegistrator.